### PR TITLE
Fix depreciation warning for Rails 6

### DIFF
--- a/lib/active_model/dynamic_errors.rb
+++ b/lib/active_model/dynamic_errors.rb
@@ -2,19 +2,20 @@ module ActiveModel
   class Errors
     # Redefine the ActiveModel::Errors::full_messages method:
     #  Returns all the full error messages in an array. 'Base' messages are handled as usual.
-    #  Non-base messages are prefixed with the attribute name as usual UNLESS 
+    #  Non-base messages are prefixed with the attribute name as usual UNLESS
     # (1) they begin with '^' in which case the attribute name is omitted.
     #     E.g. validates_acceptance_of :accepted_terms, :message => '^Please accept the terms of service'
     # (2) the message is a proc, in which case the proc is invoked on the model object.
-    #     E.g. validates_presence_of :assessment_answer_option_id, 
+    #     E.g. validates_presence_of :assessment_answer_option_id,
     #     :message => Proc.new { |aa| "#{aa.label} (#{aa.group_label}) is required" }
     #     which gives an error message like:
     #     Rate (Accuracy) is required
     def full_messages
       full_messages = []
 
-      each do |attribute, messages|
-        messages = Array.wrap(messages)
+      each do |err|
+        attribute = err.attribute
+        messages = Array.wrap(err.message)
         next if messages.empty?
 
         if attribute == :base
@@ -33,7 +34,7 @@ module ActiveModel
               full_messages << I18n.t(:"errors.dynamic_format", options.merge(:message => m.call(@base)))
             else
               full_messages << I18n.t(:"errors.format", options.merge(:message => m))
-            end            
+            end
           end
         end
       end


### PR DESCRIPTION
Fix following depreciation warning for Rails 6.

```
DEPRECATION WARNING: Enumerating ActiveModel::Errors as a hash has been deprecated.
In Rails 6.1, `errors` is an array of Error objects,
therefore it should be accessed by a block with a single block
parameter like this:

person.errors.each do |error|
  attribute = error.attribute
  message = error.message
end
```